### PR TITLE
updates cancelToken to AbortSignal

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This project aims to provide a simple single purpose generation for typescript a
 
 ## Why?
 
-Current code generators for react and typescript output code fashioned to a specific request library, but to accomodate multiple wrappers that developers may use in their own projects the library is likely fetch. This project aims to focus the generation to only one library: Axios. Ideally this prevents initial development to adapt the code generator to fit to your project.
+Current code generators for react and typescript output code fashioned to a specific request library, but to accommodate multiple wrappers that developers may use in their own projects the library is likely fetch. This project aims to focus the generation to only one library: Axios. Ideally this prevents initial development to adapt the code generator to fit to your project.
 
 ## Installation
 
@@ -16,7 +16,7 @@ If installing from a cloned repo, navigate to the root directory and then procee
 
 `npx taggem [-m] [--monolith] [path/to/input.y(a)ml] [path/to/output/]`
 This runs the generator in "monolith" mode.
-This splits your api into multiple directories based on the open api `tag` assingments and
+This splits your api into multiple directories based on the open api `tag` assignments and
 treats each tag as a servlet. It may not save your api, but it will save your eyes.
 
 `npx taggem [-s] [--service] [path/to/input.y(a)ml] [path/to/output/]`

--- a/index.js
+++ b/index.js
@@ -29,6 +29,7 @@ const pascalCase = (string) => {
  * @param {string} outputDirectory - desired output directory for generated files.
  * @param {boolean} isApiMonolith - flag indicating whether to treat this api as monolithic.
  * @param {string} userProvidedServiceName - Optional service name for api file.
+ * @param {number} axiosVersion - Optional axios version to use.
  */
 exports.generate = async (inputFile, outputDirectory, isApiMonolith, userProvidedServiceName, axiosVersion = 0) => {
 	const isAxiosVersionZero = axiosVersion < 1;

--- a/index.js
+++ b/index.js
@@ -21,21 +21,23 @@ const BAD_YAML_MESSAGE =
  * @returns a string in PascalCase
  */
 const pascalCase = (string) => {
-    // First, split the string into words using "look-ahead" & remove whitespace
-    const words = string.split(/(?=[A-Z])|[\s-_]+/).filter(word => word.length > 0);
-    
-    return words.map((word, index) => {
-        if (word.toUpperCase() === word && word.length > 1) {
-            // If the word is all uppercase and more than one character, assume it's an acronym
-            return word;
-        } else if (index === 0 || word.length > 1) {
-            // Capitalize the first letter, lowercase the rest, unless it's a single character
-            return word.charAt(0).toUpperCase() + word.slice(1).toLowerCase();
-        } else {
-            // For single characters (except the first word), just uppercase
-            return word.toUpperCase();
-        }
-    }).join('');
+	// First, split the string into words using "look-ahead" & remove whitespace
+	const words = string.split(/(?=[A-Z])|[\s-_]+/).filter((word) => word.length > 0);
+
+	return words
+		.map((word, index) => {
+			if (word.toUpperCase() === word && word.length > 1) {
+				// If the word is all uppercase and more than one character, assume it's an acronym
+				return word;
+			} else if (index === 0 || word.length > 1) {
+				// Capitalize the first letter, lowercase the rest, unless it's a single character
+				return word.charAt(0).toUpperCase() + word.slice(1).toLowerCase();
+			} else {
+				// For single characters (except the first word), just uppercase
+				return word.toUpperCase();
+			}
+		})
+		.join("");
 };
 
 /**
@@ -203,7 +205,7 @@ exports.generate = async (
 
 				let properties;
 
-				// conditionally parse an array schema based off how it is defined 
+				// conditionally parse an array schema based off how it is defined
 				if (schema.type === "array" && schema.items) {
 					if (schema.items.type === "object") {
 						// the schema explicitly defines each property of the array object
@@ -222,7 +224,10 @@ exports.generate = async (
 							PROPERTY_NAME: getSchemaName(schema.items.$ref),
 							MODEL_DESCRIPTION: schema.description,
 							PROPERTY_TYPE: translateDataType(schema.items),
-							PROPERTY_OPTIONAL: !_.includes(schema.required, getSchemaName(schema.items.$ref)),
+							PROPERTY_OPTIONAL: !_.includes(
+								schema.required,
+								getSchemaName(schema.items.$ref)
+							),
 							PROPERTY_READONLY: schema.readOnly
 						};
 					}

--- a/index.js
+++ b/index.js
@@ -21,22 +21,8 @@ const BAD_YAML_MESSAGE =
  * @returns a string in PascalCase
  */
 const pascalCase = (string) => {
-	// First, split the string into words using "look-ahead" & remove whitespace
-	const words = string.split(/(?=[A-Z])|[\s-_]+/).filter((word) => word.length > 0);
-
-	return words
-		.map((word, index) => {
-			if (word.toUpperCase() === word && word.length > 1) {
-				// If the word is all uppercase and more than one character, assume it's an acronym
-				return word;
-			} else if (index === 0 || word.length > 1) {
-				// Capitalize the first letter, lowercase the rest, unless it's a single character
-				return word.charAt(0).toUpperCase() + word.slice(1).toLowerCase();
-			} else {
-				// For single characters (except the first word), just uppercase
-				return word.toUpperCase();
-			}
-		})
+	return _.words(str, /[A-Z]+(?=[A-Z][a-z]|\d|\W)|[A-Z]?[a-z]+|\d+|[A-Z]+/g)
+		.map((word) => word.charAt(0).toUpperCase() + word.slice(1))
 		.join("");
 };
 
@@ -205,7 +191,6 @@ exports.generate = async (
 
 				let properties;
 
-			
 				if (schema.type === "array" && schema.items) {
 					// conditionally parse an array schema based off how it is defined
 					if (schema.items.type === "object" && schema.items.properties) {
@@ -225,10 +210,7 @@ exports.generate = async (
 							PROPERTY_NAME: referencedSchemaName,
 							MODEL_DESCRIPTION: schema.description,
 							PROPERTY_TYPE: translateDataType(schema.items),
-							PROPERTY_OPTIONAL: !_.includes(
-								schema.required,
-								referencedSchemaName
-							),
+							PROPERTY_OPTIONAL: !_.includes(schema.required, referencedSchemaName),
 							PROPERTY_READONLY: schema.readOnly
 						};
 					}
@@ -323,7 +305,6 @@ exports.generate = async (
 
 				let properties;
 
-				
 				if (schema.type === "array" && schema.items) {
 					// conditionally parse an array schema based off how it is defined
 					if (schema.items.$ref) {
@@ -334,7 +315,10 @@ exports.generate = async (
 							PROPERTY_TYPE: translateFieldType(allSchemas, schema.items),
 							PROPERTY_OPTIONS: getEnumEntries(allSchemas, schema.items),
 							PROPERTY_DESCRIPTION: schema.description,
-							PROPERTY_REQUIRED: _.includes(schema.items.required, referencedSchemaName),
+							PROPERTY_REQUIRED: _.includes(
+								schema.items.required,
+								referencedSchemaName
+							),
 							PROPERTY_UNITS: schema.items["x-ada-units"],
 							PROPERTY_FORMAT: schema.items.format,
 							PROPERTY_DEFAULT:
@@ -342,9 +326,7 @@ exports.generate = async (
 							PROPERTY_MINIMUM: schema.items.minimum || schema.items.minLength,
 							PROPERTY_MAXIMUM: schema.items.maximum || schema.items.maxLength
 						};
-
 					} else if (schema.items.type === "object" && schema.items.properties) {
-
 						properties = _.map(schema.items.properties, (property, propertyName) => {
 							return {
 								PROPERTY_NAME: propertyName,
@@ -361,7 +343,7 @@ exports.generate = async (
 							};
 						});
 					}
-				} else { 
+				} else {
 					properties = _.map(schema.properties, (property, propertyName) => {
 						return {
 							PROPERTY_NAME: propertyName,
@@ -371,8 +353,7 @@ exports.generate = async (
 							PROPERTY_REQUIRED: _.includes(schema.required, propertyName),
 							PROPERTY_UNITS: property["x-ada-units"],
 							PROPERTY_FORMAT: property.format,
-							PROPERTY_DEFAULT:
-								property.default || generateDefaultValue(property),
+							PROPERTY_DEFAULT: property.default || generateDefaultValue(property),
 							PROPERTY_MINIMUM: property.minimum || property.minLength,
 							PROPERTY_MAXIMUM: property.maximum || property.maxLength
 						};

--- a/index.js
+++ b/index.js
@@ -16,6 +16,7 @@ const BAD_YAML_MESSAGE =
  * @example test -> Test
  * @example test text -> TestText
  * @example test-text -> TestText
+ * @example TESTTest -> TESTTest
  * @param {string} string - input string
  * @returns a string in PascalCase
  */

--- a/index.js
+++ b/index.js
@@ -20,7 +20,21 @@ const BAD_YAML_MESSAGE =
  * @returns a string in PascalCase
  */
 const pascalCase = (string) => {
-	return _.upperFirst(_.camelCase(string));
+    // First, split the string into words using "look-ahead" & remove whitespace
+    const words = string.split(/(?=[A-Z])|[\s-_]+/).filter(word => word.length > 0);
+    
+    return words.map((word, index) => {
+        if (word.toUpperCase() === word && word.length > 1) {
+            // If the word is all uppercase and more than one character, assume it's an acronym
+            return word;
+        } else if (index === 0 || word.length > 1) {
+            // Capitalize the first letter, lowercase the rest, unless it's a single character
+            return word.charAt(0).toUpperCase() + word.slice(1).toLowerCase();
+        } else {
+            // For single characters (except the first word), just uppercase
+            return word.toUpperCase();
+        }
+    }).join('');
 };
 
 /**

--- a/index.js
+++ b/index.js
@@ -577,7 +577,6 @@ function translateDataType(schema, isForeignReference = false) {
 	} else if (schema.type === "integer") {
 		propertyType = "number";
 	} else if (schema.type === "array") {
-		console.log("schema is an array: ", schema);
 		if (!schema.items.type) {
 			propertyType = `Array<${translateDataType(schema.items, isForeignReference)}>`;
 		} else {

--- a/templates/service.mustache
+++ b/templates/service.mustache
@@ -59,7 +59,7 @@ export function {{FUNCTION_NAME}}(
 	payload: {{^FUNCTION_PAYLOAD}}undefined{{/FUNCTION_PAYLOAD}}{{#FUNCTION_PAYLOAD}}{{{.}}}{{/FUNCTION_PAYLOAD}},
 	headers: {{^IS_AXIOS_VERSION_ZERO}}RawAxiosRequestHeaders{{/IS_AXIOS_VERSION_ZERO}}{{#IS_AXIOS_VERSION_ZERO}}Record<string, unknown>{{/IS_AXIOS_VERSION_ZERO}},
 	{{#IS_AXIOS_VERSION_ZERO}}
-	cancelToken?: cancelToken,
+	cancelToken?: CancelToken,
 	{{/IS_AXIOS_VERSION_ZERO}}
 	{{^IS_AXIOS_VERSION_ZERO}}
 	signal?: signal,

--- a/templates/service.mustache
+++ b/templates/service.mustache
@@ -46,10 +46,7 @@ export interface {{FUNCTION_NAME}}QueryParams {
  * @param params - The request parameters (or undefined).
  * @param payload - the request payload (or undefined).
  * @param headers - the request headers.
- {{#IS_AXIOS_VERSION_ZERO}}
- * @param cancelToken - optional CancelToken to cancel this request.{{/IS_AXIOS_VERSION_ZERO}}
- {{^IS_AXIOS_VERSION_ZERO}}
- * @param signal - optional AbortSignal to cancel this request.{{/IS_AXIOS_VERSION_ZERO}}
+ * @param {{#IS_AXIOS_VERSION_ZERO}}cancelToken - optional cancel token{{/IS_AXIOS_VERSION_ZERO}}{{^IS_AXIOS_VERSION_ZERO}}signal - optional AbortSignal{{/IS_AXIOS_VERSION_ZERO}} to cancel this request.
  * @param queryParameters - optional request query parameters (or undefined).
  * @param basePathOverride - optional override to the base path.
  * @returns api request configuration data.
@@ -62,7 +59,7 @@ export function {{FUNCTION_NAME}}(
 	cancelToken?: CancelToken,
 	{{/IS_AXIOS_VERSION_ZERO}}
 	{{^IS_AXIOS_VERSION_ZERO}}
-	signal?: signal,
+	signal?: AbortSignal,
 	{{/IS_AXIOS_VERSION_ZERO}}	
 	queryParameters?: {{#QUERY_PARAMS}}{{FUNCTION_NAME}}QueryParams{{/QUERY_PARAMS}} | undefined,
 	basePathOverride?: string

--- a/templates/service.mustache
+++ b/templates/service.mustache
@@ -55,7 +55,12 @@ export function {{FUNCTION_NAME}}(
 	params: {{^FUNCTION_PARAMS}}undefined{{/FUNCTION_PARAMS}}{{#FUNCTION_PARAMS}}{{FUNCTION_NAME}}Params{{/FUNCTION_PARAMS}},
 	payload: {{^FUNCTION_PAYLOAD}}undefined{{/FUNCTION_PAYLOAD}}{{#FUNCTION_PAYLOAD}}{{{.}}}{{/FUNCTION_PAYLOAD}},
 	headers: {{^IS_AXIOS_VERSION_ZERO}}RawAxiosRequestHeaders{{/IS_AXIOS_VERSION_ZERO}}{{#IS_AXIOS_VERSION_ZERO}}Record<string, unknown>{{/IS_AXIOS_VERSION_ZERO}},
-	signal?: AbortSignal,
+	{{#IS_AXIOS_VERSION_ZERO}}
+	cancelToken?: cancelToken,
+	{{/IS_AXIOS_VERSION_ZERO}}
+	{{^IS_AXIOS_VERSION_ZERO}}
+	signal?: signal,
+	{{/IS_AXIOS_VERSION_ZERO}}	
 	queryParameters?: {{#QUERY_PARAMS}}{{FUNCTION_NAME}}QueryParams{{/QUERY_PARAMS}} | undefined,
 	basePathOverride?: string
 ): Promise<AxiosResponse<{{{FUNCTION_RESPONSE}}}>> {
@@ -66,7 +71,12 @@ export function {{FUNCTION_NAME}}(
 		method: "{{REQUEST_METHOD}}",
 		params: queryParameters,
 		data: payload,
+		{{#IS_AXIOS_VERSION_ZERO}}
+		cancelToken: cancelToken
+		{{/IS_AXIOS_VERSION_ZERO}}
+		{{^IS_AXIOS_VERSION_ZERO}}
 		signal: signal
+		{{/IS_AXIOS_VERSION_ZERO}}	
 	});
 }
 {{/FUNCTIONS}}

--- a/templates/service.mustache
+++ b/templates/service.mustache
@@ -5,7 +5,7 @@
 /* eslint-disable  @typescript-eslint/no-empty-interface */
 /* eslint-disable  @typescript-eslint/no-unused-vars */
 import * as ApiModelTypes from "{{{TYPES_DIRECTORY}}}";
-import axios, { AxiosResponse, CancelToken{{^IS_AXIOS_VERSION_ZERO}}, RawAxiosRequestHeaders{{/IS_AXIOS_VERSION_ZERO}} } from "axios";
+import axios, { AxiosResponse, RawAxiosRequestHeaders{{/IS_AXIOS_VERSION_ZERO}} } from "axios";
 
 /**
  * The service base path.
@@ -46,7 +46,7 @@ export interface {{FUNCTION_NAME}}QueryParams {
  * @param params - The request parameters (or undefined).
  * @param payload - the request payload (or undefined).
  * @param headers - the request headers.
- * @param cancelToken - optional cancel token to cancel this request.
+ * @param signal - optional AbortSignal to cancel this request.
  * @param queryParameters - optional request query parameters (or undefined).
  * @param basePathOverride - optional override to the base path.
  * @returns api request configuration data.
@@ -55,7 +55,7 @@ export function {{FUNCTION_NAME}}(
 	params: {{^FUNCTION_PARAMS}}undefined{{/FUNCTION_PARAMS}}{{#FUNCTION_PARAMS}}{{FUNCTION_NAME}}Params{{/FUNCTION_PARAMS}},
 	payload: {{^FUNCTION_PAYLOAD}}undefined{{/FUNCTION_PAYLOAD}}{{#FUNCTION_PAYLOAD}}{{{.}}}{{/FUNCTION_PAYLOAD}},
 	headers: {{^IS_AXIOS_VERSION_ZERO}}RawAxiosRequestHeaders{{/IS_AXIOS_VERSION_ZERO}}{{#IS_AXIOS_VERSION_ZERO}}Record<string, unknown>{{/IS_AXIOS_VERSION_ZERO}},
-	cancelToken?: CancelToken,
+	signal?: AbortSignal,
 	queryParameters?: {{#QUERY_PARAMS}}{{FUNCTION_NAME}}QueryParams{{/QUERY_PARAMS}} | undefined,
 	basePathOverride?: string
 ): Promise<AxiosResponse<{{{FUNCTION_RESPONSE}}}>> {
@@ -66,7 +66,7 @@ export function {{FUNCTION_NAME}}(
 		method: "{{REQUEST_METHOD}}",
 		params: queryParameters,
 		data: payload,
-		cancelToken: cancelToken
+		signal: signal
 	});
 }
 {{/FUNCTIONS}}

--- a/templates/service.mustache
+++ b/templates/service.mustache
@@ -5,7 +5,7 @@
 /* eslint-disable  @typescript-eslint/no-empty-interface */
 /* eslint-disable  @typescript-eslint/no-unused-vars */
 import * as ApiModelTypes from "{{{TYPES_DIRECTORY}}}";
-import axios, { AxiosResponse, RawAxiosRequestHeaders{{/IS_AXIOS_VERSION_ZERO}} } from "axios";
+import axios, { AxiosResponse{{^IS_AXIOS_VERSION_ZERO}}, RawAxiosRequestHeaders{{/IS_AXIOS_VERSION_ZERO}} } from "axios";
 
 /**
  * The service base path.

--- a/templates/service.mustache
+++ b/templates/service.mustache
@@ -5,7 +5,7 @@
 /* eslint-disable  @typescript-eslint/no-empty-interface */
 /* eslint-disable  @typescript-eslint/no-unused-vars */
 import * as ApiModelTypes from "{{{TYPES_DIRECTORY}}}";
-import axios, { AxiosResponse{{^IS_AXIOS_VERSION_ZERO}}, RawAxiosRequestHeaders{{/IS_AXIOS_VERSION_ZERO}} } from "axios";
+import axios, { AxiosResponse{{#IS_AXIOS_VERSION_ZERO}}, CancelToken{{/IS_AXIOS_VERSION_ZERO}}{{^IS_AXIOS_VERSION_ZERO}}, RawAxiosRequestHeaders{{/IS_AXIOS_VERSION_ZERO}} } from "axios";
 
 /**
  * The service base path.
@@ -46,7 +46,10 @@ export interface {{FUNCTION_NAME}}QueryParams {
  * @param params - The request parameters (or undefined).
  * @param payload - the request payload (or undefined).
  * @param headers - the request headers.
- * @param signal - optional AbortSignal to cancel this request.
+ {{#IS_AXIOS_VERSION_ZERO}}
+ * @param cancelToken - optional CancelToken to cancel this request.{{/IS_AXIOS_VERSION_ZERO}}
+ {{^IS_AXIOS_VERSION_ZERO}}
+ * @param signal - optional AbortSignal to cancel this request.{{/IS_AXIOS_VERSION_ZERO}}
  * @param queryParameters - optional request query parameters (or undefined).
  * @param basePathOverride - optional override to the base path.
  * @returns api request configuration data.


### PR DESCRIPTION
Updates deprecated `cancelToken` used in the template to `AbortSignal` through conditional use of the `IS_AXIOS_VERSION_ZERO` variable. All comments and variables in the mustache template will be updated in accordance with the value provided by the user (note that `IS_AXIOS_VERSION_ZERO` is `0` by default/no value provided). 

In other words, the `IS_AXIOS_VERSION_ZERO` variable will not only dictate which version type of the request headers will be used:
 - old: `Record<string, unknown>`, 
 - new: `RawAxiosHeaders`,
 
but also the way canceled requests are handled: 
- old : `cancelToken`
- new: `AbortSignal`

https://axios-http.com/docs/cancellation
https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal

The `pascalCase` function is also updated to account for acronyms in the names provided. If a name contains an acronym, the acronym case persists in capitals and proceeds with pascal case as normal (ex. "TESTTest" -> "TESTTest")